### PR TITLE
[UPDATE] Back to using the original SCTP library.

### DIFF
--- a/AMF/TestAmf/Init.go
+++ b/AMF/TestAmf/Init.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"git.cs.nctu.edu.tw/calee/sctp"
+	"github.com/ishidawataru/sctp"
 
 	"github.com/davecgh/go-spew/spew"
 


### PR DESCRIPTION
Back to using the original SCTP library, until errors with the new one are resolved.